### PR TITLE
DEV-5007 ♻️ Reverting to obsolete config for TrailingCommaInLiteral

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,13 +58,10 @@ RegexpLiteral:
   AllowInnerSlashes: true
   EnforcedStyle: slashes
 
-# Hashes and arrays, if multiline, must end with a comma
 # Makes it easier to add/remove lines,
 # also nicely keeps consistency with good JS style
 # (although not the end goal)
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: consistent_comma
-Style/TrailingCommaInHashLiteral:
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: consistent_comma
 
 # Having nested ifs can be useful if you're looking to refacto.


### PR DESCRIPTION
Rollback seulement sur TrailingCommaInLiteral.
Si un dev a un warning car une version trop récente de Rubocop demandant de distinguer le traitement pour Hash et Array :
gem uninstall rubocop && bundle